### PR TITLE
VT-1578: Clamp timedelta to 0 to avoid negative values

### DIFF
--- a/Sources/RTMP/RTMPTimestamp.swift
+++ b/Sources/RTMP/RTMPTimestamp.swift
@@ -21,6 +21,12 @@ struct RTMPTimestamp<T: RTMPTimeConvertible> {
             return 0
         } else {
             var timedelta = (value.seconds - updatedAt) * 1000
+
+            // Clamp timedelta to a minimum of 0 to prevent negative values
+            if timedelta < 0 {
+                timedelta = 0
+            }
+
             timedeltaFraction += timedelta.truncatingRemainder(dividingBy: 1)
             if 1 <= timedeltaFraction {
                 timedeltaFraction -= 1


### PR DESCRIPTION
[VT-1578](https://citizenteam.atlassian.net/browse/VT-1578)

QA testing and manual testing found a crash when disabling the filter effect. The TestFlight crash report pointed towards an issue with RTMPTimestamp's update function computing a negative time delta value, which would then crash when the return value attempted to init a `UInt32` with a negative value. 

This PR adds logic to clamp the time delta value to 0 if it is found to have a negative value. 

## Screenshots:

The following video was captured while streaming via RTMP through this branch of HaishinKit. The crash that had been observed when disabling the filter is no longer occurring. This test also shows that audio and video are remaining in sync. Note that in the middle of the video I also tested the audio mute function. 

https://github.com/user-attachments/assets/503ad98b-2207-47df-be3f-328289b3d9c8


